### PR TITLE
Fix being able to scroll out of bounds infinitely

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -300,11 +300,6 @@ end
 
 
 function DocView:update()
-  -- clamp to view bounds
-  local max_scroll = math.max(0, self:get_scrollable_size() - self.size.y)
-  self.scroll.y = math.min(max_scroll, self.scroll.y)
-  self.scroll.to.y = math.max(0, math.min(max_scroll, self.scroll.to.y))
-
   -- scroll to make caret visible and reset blink timer if it moved
   local line, col = self.doc:get_selection()
   if (line ~= self.last_line or col ~= self.last_col) and self.size.x > 0 then

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -300,6 +300,11 @@ end
 
 
 function DocView:update()
+  -- clamp to view bounds
+  local max_scroll = math.max(0, self:get_scrollable_size() - self.size.y)
+  self.scroll.y = math.min(max_scroll, self.scroll.y)
+  self.scroll.to.y = math.max(0, math.min(max_scroll, self.scroll.to.y))
+
   -- scroll to make caret visible and reset blink timer if it moved
   local line, col = self.doc:get_selection()
   if (line ~= self.last_line or col ~= self.last_col) and self.size.x > 0 then

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -6,7 +6,7 @@ keymap.map = {}
 keymap.reverse_map = {}
 
 
-local modkeys = { "ctrl", "alt", "shift" }
+local modkeys = { "ctrl", "left alt", "shift" }
 
 local function modkey(key)
   for _, k in ipairs(modkeys) do


### PR DESCRIPTION
Without this, you can scroll inside a file without an unbounded range, i.e. outside the bounds defined by the first and last lines of the file.

(Thank you for your work on this project! Really was surprised when I saw it in my github dashboard)