### PR TITLE
Scroll limits

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -274,12 +274,16 @@ end
 
 
 function DocView:on_mouse_moved(x, y, ...)
-  DocView.super.on_mouse_moved(self, x, y, ...)
+  local caught = DocView.super.on_mouse_moved(self, x, y, ...)
 
   if self:scrollbar_overlaps_point(x, y) or self.dragging_scrollbar then
     self.cursor = "arrow"
-  else
+  elseif not caught then
     self.cursor = "ibeam"
+  end
+
+  if caught then
+    return
   end
 
   if self.mouse_selecting then

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -241,8 +241,8 @@ end
 
 
 function DocView:scroll_to_make_visible(line, col)
-  local min = self:get_line_height() * (line - 1)
-  local max = self:get_line_height() * (line + 2) - self.size.y
+  local min = self:get_line_height() * (line - 1) + style.padding.y
+  local max = self:get_line_height() * (line + 2) - self.size.y + style.padding.y
   self.scroll.to.y = math.min(self.scroll.to.y, min)
   self.scroll.to.y = math.max(self.scroll.to.y, max)
   local gw = self:get_gutter_width()

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -127,7 +127,7 @@ end
 
 
 function DocView:get_scrollable_size()
-  return self:get_line_height() * #self.doc.lines + style.padding.y * 2
+  return self:get_line_height() * (#self.doc.lines-1) + style.padding.y * 2
 end
 
 
@@ -236,6 +236,7 @@ function DocView:scroll_to_line(line, ignore_if_visible, instant)
       self.scroll.y = self.scroll.to.y
     end
   end
+  self:clamp_scroll()
 end
 
 
@@ -248,6 +249,7 @@ function DocView:scroll_to_make_visible(line, col)
   local xoffset = self:get_col_x_offset(line, col)
   local max = xoffset - self.size.x + gw + self.size.x / 5
   self.scroll.to.x = math.max(0, max)
+  self:clamp_scroll()
 end
 
 

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -99,8 +99,10 @@ function View:on_mouse_moved(x, y, dx, dy)
     local delta = scrollable / self.size.y * dy
     self.scroll.to.y = self.scroll.to.y + delta
     self:clamp_scroll()
+    return true
   end
   self.hovered_scrollbar = self:scrollbar_overlaps_point(x, y)
+  return false
 end
 
 

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -53,6 +53,19 @@ function TreeView:get_item_height()
 end
 
 
+function TreeView:get_scrollable_size()
+  local count = 0
+  for item in self:each_item() do
+    count = count + 1
+  end
+  if count <= 0 then
+    count = 1
+  end
+
+  return self:get_item_height() * (count-1) + style.padding.y * 2
+end
+
+
 function TreeView:check_cache()
   -- invalidate cache's skip values if project_files has changed
   if core.project_files ~= self.last_project_files then
@@ -99,7 +112,13 @@ function TreeView:each_item()
 end
 
 
-function TreeView:on_mouse_moved(px, py)
+function TreeView:on_mouse_moved(px, py, ...)
+  local caught = TreeView.super.on_mouse_moved(self, px, py, ...)
+  if caught then
+    self.hovered_item = nil
+    return
+  end
+
   self.hovered_item = nil
   for item, x,y,w,h in self:each_item() do
     if px > x and py > y and px <= x + w and py <= y + h then
@@ -110,7 +129,12 @@ function TreeView:on_mouse_moved(px, py)
 end
 
 
-function TreeView:on_mouse_pressed(button, x, y)
+function TreeView:on_mouse_pressed(button, x, y, clicks)
+  local caught = TreeView.super.on_mouse_pressed(self, button, x, y, clicks)
+  if caught then
+    return
+  end
+
   if not self.hovered_item then
     return
   elseif self.hovered_item.type == "dir" then
@@ -120,6 +144,11 @@ function TreeView:on_mouse_pressed(button, x, y)
       core.root_view:open_doc(core.open_doc(self.hovered_item.filename))
     end)
   end
+end
+
+
+function TreeView:on_mouse_released(button)
+  TreeView.super.on_mouse_released(self, button)
 end
 
 
@@ -178,6 +207,8 @@ function TreeView:draw()
     x = x + spacing
     x = common.draw_text(style.font, color, item.name, nil, x, y, 0, h)
   end
+
+  self:draw_scrollbar()
 end
 
 


### PR DESCRIPTION
With these changes scrolling is clamped to the the minimum scroll has the first line at the top of the view and the max scroll has the last line at the top of the view while gracefully handling single line files. It also applies the same changes to the TreeView plugin.

However due to the tiny default scrollbar width and the UI taking over the mouse at the TreeView <-> DocView render border for resizing (despite the TreeView being locked) it proved difficult to drag the scrollbar on the TreeView, but it is possible and works correctly (changing any of this would be out of the scope of this PR and I don't know your preference on these things).

I also noticed that `scrollbar_overlaps_point` does not respect the exact scrollbar rect bounds (seemingly on purpose) but again, out of the scope of this PR.

Views with no/single items draw their scrollbar as with these changes it seemed the most "correct" but of course, your preference. I figured that the stuff like that would be best handled with some sort of settings system but I don't know your plans in that area or if you even want settings/configuration at all, I don't know. (Perhaps there is already some system of this kind that I've simply overlooked)