### PR TITLE
Make it possible to set the window opacity from Lua

### DIFF
--- a/src/api/system.c
+++ b/src/api/system.c
@@ -313,6 +313,13 @@ static int f_fuzzy_match(lua_State *L) {
   return 1;
 }
 
+static int f_set_window_opacity(lua_State *L) {
+  double n = luaL_checknumber(L, 1);
+  int r = SDL_SetWindowOpacity(window, n);
+  lua_pushboolean(L, r > -1);
+  return 1;
+}
+
 
 static const luaL_Reg lib[] = {
   { "poll_event",          f_poll_event          },
@@ -328,6 +335,7 @@ static const luaL_Reg lib[] = {
   { "get_time",            f_get_time            },
   { "sleep",               f_sleep               },
   { "fuzzy_match",         f_fuzzy_match         },
+  { "set_window_opacity",  f_set_window_opacity  },
   { NULL, NULL }
 };
 


### PR DESCRIPTION
Exposes the SDL_SetWindowOpacity function to Lua as system.set_window_opacity,
So you can customise the transparency of the window, nice for if you want to see your desktop background or other windows while editting.

![image](https://user-images.githubusercontent.com/57834646/74032159-34a9cd00-49ab-11ea-8358-221a8af4db55.png)
