### PR TITLE
Added ability to draw whitespace

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -16,5 +16,6 @@ config.line_height = 1.2
 config.indent_size = 2
 config.tab_type = "soft"
 config.line_limit = 80
+config.draw_whitespace = false
 
 return config

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -346,6 +346,21 @@ function DocView:draw_line_text(idx, x, y)
     local color = style.syntax[type]
     tx = renderer.draw_text(font, text, tx, ty, color)
   end
+
+  if config.draw_whitespace then
+    local color = style.whitespace
+    tx = x
+    for i = 1, #cl.text do
+      local char = cl.text:sub(i, i)
+      local width = font:get_width(char)
+      if char == " " then
+        renderer.draw_text(font, ".", tx, ty, color)
+      elseif char == "\t" then
+        renderer.draw_text(font, "›", tx, ty, color)
+      end
+      tx = tx + width
+    end
+  end
 end
 
 

--- a/data/core/style.lua
+++ b/data/core/style.lua
@@ -26,6 +26,7 @@ style.line_number2 = { common.color "#73739e" }
 style.line_highlight = { common.color "#252533" }
 style.scrollbar = { common.color "#323245" }
 style.scrollbar2 = { common.color "#3b3b52" }
+style.whitespace = { common.color "rgba(255, 255, 255, 0.2)" }
 
 style.syntax = {}
 style.syntax["normal"] = { common.color "#F5F5F5" }

--- a/data/user/colors/fall.lua
+++ b/data/user/colors/fall.lua
@@ -15,6 +15,7 @@ style.line_number2 = { common.color "#615d5f" }
 style.line_highlight = { common.color "#383637" }
 style.scrollbar = { common.color "#454344" }
 style.scrollbar2 = { common.color "#524F50" }
+style.whitespace = { common.color "rgba(255, 255, 255, 0.2)" }
 
 style.syntax["normal"] = { common.color "#efdab9" }
 style.syntax["symbol"] = { common.color "#efdab9" }

--- a/data/user/colors/summer.lua
+++ b/data/user/colors/summer.lua
@@ -15,6 +15,7 @@ style.line_number2 = { common.color "#808080" }
 style.line_highlight = { common.color "#f2f2f2" }
 style.scrollbar = { common.color "#e0e0e0" }
 style.scrollbar2 = { common.color "#c0c0c0" }
+style.whitespace = { common.color "rgba(0, 0, 0, 0.2)" }
 
 style.syntax["normal"] = { common.color "#181818" }
 style.syntax["symbol"] = { common.color "#181818" }


### PR DESCRIPTION
I know changes to core are looked down upon, but I've been coding with whitespace visible for a long time! This only adds 19 lines, so I'd say it's pretty light for the added benefit.

I don't think it could be added as a plugin unless some pre / post hooks were added to `DocView:draw_line_text`. That might be better anyways as it could allow plugins to do all sorts of line based things (think GitLens style line history, minus the jank caused by vscode).

If this ends up being merged, I think a nice change would be to swap out the characters with the ones that vscode uses:

![image](https://user-images.githubusercontent.com/4952718/79772876-a765eb80-82fe-11ea-80d1-593d3a1c4393.png)

I'm guessing these would go into icons.ttf