### PR TITLE
Added goto to lua language plugin

### DIFF
--- a/data/plugins/language_lua.lua
+++ b/data/plugins/language_lua.lua
@@ -17,6 +17,7 @@ syntax.add {
     { pattern = "[%+%-=/%*%^%%#<>]",      type = "operator" },
     { pattern = "[%a_][%w_]*%s*%f[(\"{]", type = "function" },
     { pattern = "[%a_][%w_]*",            type = "symbol"   },
+    { pattern = "::[%a_][%w_]*::",        type = "literal"  },
   },
   symbols = {
     ["if"]       = "keyword",
@@ -37,6 +38,7 @@ syntax.add {
     ["not"]      = "keyword",
     ["and"]      = "keyword",
     ["or"]       = "keyword",
+    ["goto"]     = "keyword",
     ["self"]     = "keyword2",
     ["true"]     = "literal",
     ["false"]    = "literal",


### PR DESCRIPTION
The only caveat is that I don't think it's possible to highlight the literal after the `goto` keyword.