### PR TITLE
Updated scaling method

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -16,9 +16,9 @@ SDL_Window *window;
 
 
 static double get_scale(void) {
-	SDL_DisplayMode dm;
-	SDL_GetDesktopDisplayMode(0, &dm);
-	return dm.h / 786.0;
+	float vdpi;
+	SDL_GetDisplayDPI(0, NULL, NULL, &vdpi);
+	return vdpi / 224.0;
 }
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -16,15 +16,9 @@ SDL_Window *window;
 
 
 static double get_scale(void) {
-  float dpi;
-  SDL_GetDisplayDPI(0, NULL, &dpi, NULL);
-#if _WIN32
-  return dpi / 96.0;
-#elif __APPLE__
-  return dpi / 72.0;
-#else
-  return 1.0;
-#endif
+	SDL_DisplayMode dm;
+	SDL_GetDesktopDisplayMode(0, &dm);
+	return dm.h / 786.0;
 }
 
 


### PR DESCRIPTION
This does display scaling based on screen height (width won't be consistent because of ultra-wide displays) rather than a platform-based guess.  Tested on Catalina, Arch, and Win10.