### PR TITLE
Fixing trimwhitespace plugin bug

### DIFF
--- a/data/plugins/trimwhitespace.lua
+++ b/data/plugins/trimwhitespace.lua
@@ -17,7 +17,7 @@ end
 
 command.add("core.docview", {
   ["trim-whitespace:trim-trailing-whitespace"] = function()
-    trim_trailing_whitespace(self.active_view.doc)
+    trim_trailing_whitespace(core.active_view.doc)
   end,
 })
 


### PR DESCRIPTION
I was experimenting with lite, and trying to use "trimwhitespace" plugin I got the following error:
![image](https://user-images.githubusercontent.com/12432805/81501978-85cea300-92b1-11ea-9dfe-7e13ba8119fd.png)


This MR fix that