### PR TITLE
Fixed various issues in exec:replace

### DIFF
--- a/data/plugins/exec.lua
+++ b/data/plugins/exec.lua
@@ -2,11 +2,21 @@ local core = require "core"
 local command = require "core.command"
 
 
-local function exec(cmd)
+local function exec(cmd, keep_newline)
   local fp = io.popen(cmd, "r")
   local res = fp:read("*a")
   fp:close()
-  return res:gsub("%\n$", "")
+  return keep_newline and res or res:gsub("%\n$", "")
+end
+
+
+local function printfb_quote(str)
+  local sub = {
+    ["\\"] = "\\\\",
+    [string.char(0)] = "\\0000",
+    ["'"] = "'\\''",
+  }
+  return "'" .. str:gsub(".", sub) .. "'"
 end
 
 
@@ -20,7 +30,10 @@ command.add("core.docview", {
   ["exec:replace"] = function()
     core.command_view:enter("Replace With Result Of Command", function(cmd)
       core.active_view.doc:replace(function(str)
-        return exec(string.format("echo %q | %s", str, cmd))
+        return exec(
+          "printf %b " .. printfb_quote(str:gsub("%\n$", "") .. "\n") .. " | " .. cmd,
+          str:find("%\n$")
+        )
       end)
     end)
   end,


### PR DESCRIPTION
This commit assumes the exec plugin will use a POSIX compliant shell.

### Issues

These are currently the issues with the `exec:replace` command :
- The `echo` shell command does not always output his first argument as is. This behavior actually depends on the shell used.
- Lua's `string.format` function doesn't quote properly for the shell.
- A newline is added to the input of the command even when an entire line is selected.

### Test cases

#### using `exec:replace` with `cat`

For the following cases, the expected behavior is always to keep the selected text as is.
The shell used is `sh` as an alias of `dash`.

Selected text | Result | Reason
------------- | ------ | ------
-n | | `echo`'s behavior
\0142\0141\0144 | bad | `echo`'s behavior
line1`an actual newline`line2 | line1line2 | Lua's `string.format` not quoting newline properly for the shell

#### using `exec:replace` with `wc -l`

By selecting a line by triple clicking it, the result will be _2_ instead of _1_.

### Solutions

These modifications has been made to fix the issues :
- Using `printf` instead of `echo`
- Quoting the selected text considering the shell syntax
- Not touching newlines in the input and the output of the shell command if there is one at the end of the selection

`printf %b` has been used instead of `printf %s` with appropriate quoting to allow a _null byte_ from the selected text to be used without breaking the command.
