### PR TITLE
Added FreeLibrary() to release user32 module

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -138,6 +138,10 @@ int main(int argc, char **argv) {
 
   lua_close(L);
   SDL_DestroyWindow(window);
-
+  
+#ifdef _WIN32
+  FreeLibrary(lib);
+#endif
+  
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
I don't know why...
`SetProcessDPIAware` is used by creating new instance of user32 module.
But this instance should be released.

By default, user32 is linked by compiler, just `extern` this function.
```c
#ifdef _WIN32
extern int SetProcessDPIAware();
#endif
```

