### PR TITLE
Enable LUA_USE_POSIX, fix tmpnam warning on macOS.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-cflags="-Wall -O3 -g -std=gnu11 -Isrc -DLUA_USE_POPEN"
+cflags="-Wall -O3 -g -std=gnu11 -Isrc"
 lflags="-lSDL2 -lm"
 
 if [[ $* == *windows* ]]; then
   platform="windows"
   outfile="lite.exe"
   compiler="x86_64-w64-mingw32-gcc"
-  cflags="$cflags -Iwinlib/SDL2-2.0.10/x86_64-w64-mingw32/include"
+  cflags="$cflags -DLUA_USE_POPEN -Iwinlib/SDL2-2.0.10/x86_64-w64-mingw32/include"
   lflags="$lflags -Lwinlib/SDL2-2.0.10/x86_64-w64-mingw32/lib"
   lflags="-lmingw32 -lSDL2main $lflags -mwindows -o $outfile res.res"
   x86_64-w64-mingw32-windres res.rc -O coff -o res.res
@@ -15,6 +15,7 @@ else
   platform="unix"
   outfile="lite"
   compiler="gcc"
+  cflags="$cflags -DLUA_USE_POSIX"
   lflags="$lflags -o $outfile"
 fi
 


### PR DESCRIPTION
On macOS, we want to use `mkstemp` rather than `tmpnam`. Enable
POSIX support in Lua to fix that (and some other things). Since
POSIX support also enables the flag for POPEN, we no longer need
to do that directly for Linux.