### PR TITLE
Improve movement through words

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -8,7 +8,8 @@ config.mouse_wheel_scroll = 50 * SCALE
 config.file_size_limit = 10
 config.ignore_files = "^%."
 config.symbol_pattern = "[%a_][%w_]*"
-config.non_word_chars = " \t\n/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-"
+config.whitespace_chars = " \t\n"
+config.operator_chars = "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-"
 config.undo_merge_timeout = 0.3
 config.max_undos = 10000
 config.highlight_current_line = true

--- a/data/core/doc/translate.lua
+++ b/data/core/doc/translate.lua
@@ -43,15 +43,13 @@ end
 function translate.previous_word_boundary(doc, line, col)
   local c = doc:get_char(doc:position_offset(line, col, -1))
 
-  if is_whitespace(c) then
-    repeat
-      local line2, col2 = line, col
-      line, col = doc:position_offset(line, col, -1)
+  while is_whitespace(c) do
+    local line2, col2 = line, col
+    line, col = doc:position_offset(line, col, -1)
       if line == line2 and col == col2 then
         break
       end
       c = doc:get_char(doc:position_offset(line, col, -1))
-    until not is_whitespace(c)
   end
 
   local is_word
@@ -75,15 +73,13 @@ end
 function translate.next_word_boundary(doc, line, col)
   local c = doc:get_char(line, col)
 
-  if is_whitespace(c) then
-    repeat
-      local line2, col2 = line, col
-      line, col = doc:position_offset(line, col, 1)
-      if line == line2 and col == col2 then
-        break
-      end
-      c = doc:get_char(line, col)
-    until not is_whitespace(c)
+  while is_whitespace(c) do
+    local line2, col2 = line, col
+    line, col = doc:position_offset(line, col, 1)
+    if line == line2 and col == col2 then
+      break
+    end
+    c = doc:get_char(line, col)
   end
 
   local is_word

--- a/data/core/doc/translate.lua
+++ b/data/core/doc/translate.lua
@@ -29,31 +29,53 @@ end
 
 
 function translate.previous_word_boundary(doc, line, col)
-  local char = doc:get_char(doc:position_offset(line, col, -1))
-  local inword = not is_non_word(char)
+  local c = doc:get_char(doc:position_offset(line, col, -1))
+
+  if is_non_word(c) then
+    repeat
+      local line2, col2 = line, col
+      line, col = doc:position_offset(line, col, -1)
+      if line == line2 and col == col2 then
+        break
+      end
+      c = doc:get_char(doc:position_offset(line, col, -1))
+    until not is_non_word(c)
+  end
+
   repeat
     local line2, col2 = line, col
     line, col = doc:position_offset(line, col, -1)
     if line == line2 and col == col2 then
       break
     end
-    local c = doc:get_char(doc:position_offset(line, col, -1))
-  until inword and is_non_word(c) or not inword and c ~= char
+    c = doc:get_char(doc:position_offset(line, col, -1))
+  until is_non_word(c)
   return line, col
 end
 
 
 function translate.next_word_boundary(doc, line, col)
-  local char = doc:get_char(line, col)
-  local inword = not is_non_word(char)
+  local c = doc:get_char(line, col)
+
+  if is_non_word(c) then
+    repeat
+      local line2, col2 = line, col
+      line, col = doc:position_offset(line, col, 1)
+      if line == line2 and col == col2 then
+        break
+      end
+      c = doc:get_char(line, col)
+    until not is_non_word(c)
+  end
+
   repeat
     local line2, col2 = line, col
     line, col = doc:position_offset(line, col, 1)
     if line == line2 and col == col2 then
       break
     end
-    local c = doc:get_char(line, col)
-  until inword and is_non_word(c) or not inword and c ~= char
+    c = doc:get_char(line, col)
+  until is_non_word(c)
   return line, col
 end
 


### PR DESCRIPTION
We skip all the white space if we are not in a word and go to the beginning of the word (w/previous_word_boundary) or the end of the word (w/next_word_boundary).

E.g. Current behavior on each `doc:move-to-previous-word-boundary`:
```
this   is   some  text
                    ^
this   is   some  text
                  ^
this   is   some  text
                ^
this   is   some  text
            ^
this   is   some  text
         ^
this   is   some  text
       ^
this   is   some  text
    ^
````
New behavior:
```
this   is   some  text
                    ^
this   is   some  text
                  ^
this   is   some  text
            ^
this   is   some  text
       ^
this   is   some  text
^
````

Same for `doc:move-to-next-word-boundary`