### PR TITLE
Make lite working on FreeBSD

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cflags="-Wall -O3 -g -std=gnu11 -fno-strict-aliasing -Isrc"
 lflags="-lSDL2 -lm"
@@ -14,7 +14,7 @@ if [[ $* == *windows* ]]; then
 else
   platform="unix"
   outfile="lite"
-  compiler="gcc"
+  compiler="cc"
   cflags="$cflags -DLUA_USE_POSIX"
   lflags="$lflags -o $outfile"
 fi

--- a/build.sh
+++ b/build.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
 cflags="-Wall -O3 -g -std=gnu11 -fno-strict-aliasing -Isrc"
-lflags="-lSDL2 -lm"
+lflags="-lm"
 
 if [[ $* == *windows* ]]; then
   platform="windows"
   outfile="lite.exe"
   compiler="x86_64-w64-mingw32-gcc"
   cflags="$cflags -DLUA_USE_POPEN -Iwinlib/SDL2-2.0.10/x86_64-w64-mingw32/include"
-  lflags="$lflags -Lwinlib/SDL2-2.0.10/x86_64-w64-mingw32/lib"
+  lflags="$lflags -lSDL2 -Lwinlib/SDL2-2.0.10/x86_64-w64-mingw32/lib"
   lflags="-lmingw32 -lSDL2main $lflags -mwindows -o $outfile res.res"
   x86_64-w64-mingw32-windres res.rc -O coff -o res.res
 else
@@ -17,6 +17,12 @@ else
   compiler="cc"
   cflags="$cflags -DLUA_USE_POSIX"
   lflags="$lflags -o $outfile"
+  if command -v pkgconf >/dev/null; then
+    cflags="$cflags $(pkgconf --cflags --silence-errors sdl2)"
+    lflags="$lflags $(pkgconf --libs --silence-errors sdl2)"
+  else
+    lflags="$lflags -lSDL2"
+  fi
 fi
 
 if command -v ccache >/dev/null; then

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,8 @@
   #include <unistd.h>
 #elif __APPLE__
   #include <mach-o/dyld.h>
+#elif __FreeBSD__
+  #include <stdlib.h>
 #endif
 
 
@@ -26,7 +28,7 @@ static double get_scale(void) {
 }
 
 
-static void get_exe_filename(char *buf, int sz) {
+static void get_exe_filename(const char *self, char *buf, int sz) {
 #if _WIN32
   int len = GetModuleFileName(NULL, buf, sz - 1);
   buf[len] = '\0';
@@ -38,6 +40,8 @@ static void get_exe_filename(char *buf, int sz) {
 #elif __APPLE__
   unsigned size = sz;
   _NSGetExecutablePath(buf, &size);
+#elif __FreeBSD__
+  realpath(self, buf);
 #else
   strcpy(buf, "./lite");
 #endif
@@ -111,8 +115,13 @@ int main(int argc, char **argv) {
   lua_pushnumber(L, get_scale());
   lua_setglobal(L, "SCALE");
 
+#ifdef __FreeBSD__
+  char exename[PATH_MAX];
+#else
   char exename[2048];
-  get_exe_filename(exename, sizeof(exename));
+#endif
+
+  get_exe_filename(argv[0], exename, sizeof(exename));
   lua_pushstring(L, exename);
   lua_setglobal(L, "EXEFILE");
 


### PR DESCRIPTION
This PR makes `lite` working on FreeBSD, by fixing up build.sh and add proper path detection support on FreeBSD.

Note that I use `realpath` on FreeBSD. `realpath` is also available under Linux, but only when `_DEFAULT_SOURCE` is defined. I'm not going to change path detection on Linux, as it seems to work and you probably had a good reason to use `/proc` directly.

I didn't change `build_release.sh`, as I'm not using it at all. I leave it up to you to change it if you so desire.