### PR TITLE
Use XML highlight for SVG files

### DIFF
--- a/data/plugins/language_xml.lua
+++ b/data/plugins/language_xml.lua
@@ -1,7 +1,7 @@
 local syntax = require "core.syntax"
 
 syntax.add {
-  files = { "%.xml$", "%.html?$" },
+  files = { "%.xml$", "%.html?$", "%.svg$" },
   patterns = {
     { pattern = { "<!%-%-", "%-%->" },     type = "comment"  },
     { pattern = { '%f[^>][^<]', '%f[<]' }, type = "normal"   },


### PR DESCRIPTION
> Scalable Vector Graphics (SVG) is an Extensible Markup Language (XML)-based vector image format

It seems like it would make sense to piggy back on the XML syntax highlighter rather than copying it and adding it as a plugin.

In action:
![image](https://user-images.githubusercontent.com/6697648/83963296-26aa8100-a8a5-11ea-93b4-5c6148b094b6.png)
