### PR TITLE
language_lua.lua: added <const> and <close>

### DIFF
--- a/data/plugins/language_lua.lua
+++ b/data/plugins/language_lua.lua
@@ -13,6 +13,8 @@ syntax.add {
     { pattern = "-?0x%x+",                type = "number"   },
     { pattern = "-?%d+[%d%.eE]*",         type = "number"   },
     { pattern = "-?%.?%d+",               type = "number"   },
+    { pattern = "<const>",                type = "keyword2" },
+    { pattern = "<close>",                type = "keyword2" },
     { pattern = "%.%.%.?",                type = "operator" },
     { pattern = "[<>~=]=",                type = "operator" },
     { pattern = "[%+%-=/%*%^%%#<>]",      type = "operator" },


### PR DESCRIPTION
Yesterday Lua 5.4 was released, so I added the attributes `<const>` and `<close>` to `language_lua.lua`.