### PR TITLE
Replace bitmap-baking with stb_truetype packing context

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -111,7 +111,7 @@ static GlyphSet* load_glyphset(RenFont *font, int idx) {
   /* init image */
   int width = 128;
   int height = 128;
-	stbtt_pack_context pc;
+  stbtt_pack_context pc;
 
 retry:
   set->image = ren_new_image(width, height);

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -116,7 +116,7 @@ static GlyphSet* load_glyphset(RenFont *font, int idx) {
 retry:
   set->image = ren_new_image(width, height);
   float s =
-		stbtt_ScaleForMappingEmToPixels(&font->stbfont, 1) /
+    stbtt_ScaleForMappingEmToPixels(&font->stbfont, 1) /
     stbtt_ScaleForPixelHeight(&font->stbfont, 1);
 
   stbtt_PackBegin(&pc, (void*) set->image->pixels, width, height, 0, 1, NULL);

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -14,7 +14,7 @@ struct RenImage {
 
 typedef struct {
   RenImage *image;
-  stbtt_bakedchar glyphs[256];
+  stbtt_packedchar glyphs[256];
 } GlyphSet;
 
 struct RenFont {
@@ -111,16 +111,18 @@ static GlyphSet* load_glyphset(RenFont *font, int idx) {
   /* init image */
   int width = 128;
   int height = 128;
+	stbtt_pack_context pc;
+
 retry:
   set->image = ren_new_image(width, height);
-
-  /* load glyphs */
   float s =
-    stbtt_ScaleForMappingEmToPixels(&font->stbfont, 1) /
+		stbtt_ScaleForMappingEmToPixels(&font->stbfont, 1) /
     stbtt_ScaleForPixelHeight(&font->stbfont, 1);
-  int res = stbtt_BakeFontBitmap(
-    font->data, 0, font->size * s, (void*) set->image->pixels,
-    width, height, idx * 256, 256, set->glyphs);
+
+  stbtt_PackBegin(&pc, (void*) set->image->pixels, width, height, 0, 1, NULL);
+  stbtt_PackSetOversampling(&pc, 1, 1);
+  int res = stbtt_PackFontRange(&pc, font->data, 0, font->size * s, idx*256, 256, set->glyphs);
+  stbtt_PackEnd(&pc);
 
   /* retry with a larger image buffer if the buffer wasn't large enough */
   if (res < 0) {
@@ -189,10 +191,10 @@ RenFont* ren_load_font(const char *filename, float size) {
   font->height = (ascent - descent + linegap) * scale + 0.5;
 
   /* make tab and newline glyphs invisible */
-  stbtt_bakedchar *g = get_glyphset(font, '\n')->glyphs;
+  stbtt_packedchar *g = get_glyphset(font, '\n')->glyphs;
   g['\t'].x1 = g['\t'].x0;
   g['\n'].x1 = g['\n'].x0;
-
+	
   return font;
 
 fail:
@@ -235,7 +237,7 @@ int ren_get_font_width(RenFont *font, const char *text) {
   while (*p) {
     p = utf8_to_codepoint(p, &codepoint);
     GlyphSet *set = get_glyphset(font, codepoint);
-    stbtt_bakedchar *g = &set->glyphs[codepoint & 0xff];
+    stbtt_packedchar *g = &set->glyphs[codepoint & 0xff];
     x += g->xadvance;
   }
   return x;
@@ -340,7 +342,7 @@ int ren_draw_text(RenFont *font, const char *text, int x, int y, RenColor color)
   while (*p) {
     p = utf8_to_codepoint(p, &codepoint);
     GlyphSet *set = get_glyphset(font, codepoint);
-    stbtt_bakedchar *g = &set->glyphs[codepoint & 0xff];
+    stbtt_packedchar *g = &set->glyphs[codepoint & 0xff];
     rect.x = g->x0;
     rect.y = g->y0;
     rect.width = g->x1 - g->x0;


### PR DESCRIPTION
First, thanks for your work in creating a simple but easily expandable editor. My daily driver is somewhat lacking in RAM so electron-based IDEs, while nice and featureful, really take a noticeable hit on my system. This editor runs very smooth and, well, light.

I tend to prefer small fonts for viewing code, and I've noticed that the app tends to render them a bit blurry, which distracts me a lot from the code I'm trying to read. I've attempted to dig into the stb library used here and see if I can fix the problem. So far, I have not.

However, after consulting some of the verbose comments the [stb_truetype header file](https://github.com/nothings/stb/blob/master/stb_truetype.h), I've made some edits to the rendering code that have a _very_ slight improvement to the font rendering. My goal was to be able to use `stbtt_PackSetOversampling(&pc, 1, 1);` with values greater than `1, 1`. The docs make a relevant promise:
>// Oversampling a font increases the quality by allowing higher-quality subpixel
>// positioning, and is especially valuable at smaller text sizes.

However I am observing odd behavior (the text becomes wavy and misaligned) and so far haven't been able to fix it. However, I felt the very slight improvements I'm seeing in the font rendering now are worth contributing. My hope is perhaps with your familiarity with the library you can easily spot the reason as to why oversampling causes the text to misalign (or at the very least maybe point me in the right direction for me to try things out myself).

Given this API listing in the aformentioned header:
```C
//   Simple 3D API (don't ship this, but it's fine for tools and quick start)
//           stbtt_BakeFontBitmap()               -- bake a font to a bitmap for use as texture
//           stbtt_GetBakedQuad()                 -- compute quad to draw for a given char
//
//   Improved 3D API (more shippable):
//           #include "stb_rect_pack.h"           -- optional, but you really want it
//           stbtt_PackBegin()
//           stbtt_PackSetOversampling()          -- for improved quality on small fonts
//           stbtt_PackFontRanges()               -- pack and renders
//           stbtt_PackEnd()
//           stbtt_GetPackedQuad()
```

I expected to find calls to `stbtt_GetBakedQuad()` but there are none, though I suspect some of the code I'm seeing here is a local implementation of this function? If you could point out which lines of code in `renderer.c` might be analogous to `stbtt_GetBakedQuad()` I could investigate substituting with `stbtt_GetPackedQuad()` which I hope will resolve the issue.

I am mostly using [stb's oversample example](https://github.com/nothings/stb/blob/master/tests/oversample/main.c) as a reference.
