### PR TITLE
add system.popen

### DIFF
--- a/src/api/system.c
+++ b/src/api/system.c
@@ -417,8 +417,8 @@ static int f_popen(lua_State *L) {
   CloseHandle(pi.hProcess);
   CloseHandle(pi.hThread);
 #else
-  FILE* pipe = popen(cmd, "rb");
-  if (pipe == NULL) { luaL_error(L, "Failed to start process"); }
+  FILE* pipe = popen(cmd, "r");
+  if (pipe == NULL) { luaL_error(L, "Failed to start process: %d", errno); }
 
   size_t read;
   while(!feof(pipe)) {
@@ -426,7 +426,8 @@ static int f_popen(lua_State *L) {
     read = fread(b, sizeof(char), LUAL_BUFFERSIZE, pipe);
     luaL_addsize(&stdoutBuf, read);
   }
-  exitCode = WEXITSTATUS(pclose(pipe));
+  int status = pclose(pipe);
+  if (WIFEXITED(status)) { exitCode = WEXITSTATUS(status); }
 #endif
   luaL_pushresult(&stdoutBuf);
   lua_pushnumber(L, exitCode);

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -418,7 +418,7 @@ static int f_popen(lua_State *L) {
   CloseHandle(pi.hThread);
 #else
   FILE* pipe = popen(cmd, "rb");
-  if (pipe == NULL) { luaL_error("Failed to start process"); }
+  if (pipe == NULL) { luaL_error(L, "Failed to start process"); }
 
   size_t read;
   while(!feof(pipe)) {


### PR DESCRIPTION
[Lua's `io.popen` opens a "Console window" when used.](https://github.com/drmargarido/linters/issues/14)

This PR addresses that issue by using Windows' `CreateProcess` with `CREATE_NO_WINDOW` to prevent that from happening. For compatibility, a simple wrapper over `popen` is provided for non Windows systems.

It has been a while since I wrote any C code. Suggestions are welcome :)