### PR TITLE
Stop scanning project file when a maximum limit is reached

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -16,5 +16,6 @@ config.line_height = 1.2
 config.indent_size = 2
 config.tab_type = "soft"
 config.line_limit = 80
+config.max_project_files = 2000
 
 return config


### PR DESCRIPTION
To avoid excessive memory usage when opening in a directory with too many files. Address issue https://github.com/rxi/lite/issues/208.

Introduce the config variable config.max_project_files to choose the limit.

The mechanism introduced avoid using excessive memory but it fails to
let user access all the files in the directory. A better implementation
should not impose any limits but read each subdirectory on-demand, only
as they are expanded in the tree-view.