### PR TITLE
Removed duplicated definition of "const" keyword

### DIFF
--- a/data/plugins/language_c.lua
+++ b/data/plugins/language_c.lua
@@ -41,7 +41,6 @@ syntax.add {
     ["case"]     = "keyword",
     ["default"]  = "keyword",
     ["auto"]     = "keyword",
-    ["const"]    = "keyword",
     ["void"]     = "keyword",
     ["int"]      = "keyword2",
     ["short"]    = "keyword2",


### PR DESCRIPTION
My lua extension in vs code warned me about this repetition of the table's index