### PR TITLE
Improve left/right scrolling behavior for DocView

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -187,8 +187,14 @@ function DocView:scroll_to_make_visible(line, col)
   self.scroll.to.y = math.max(self.scroll.to.y, max)
   local gw = self:get_gutter_width()
   local xoffset = self:get_col_x_offset(line, col)
-  local max = xoffset - self.size.x + gw + self.size.x / 5
-  self.scroll.to.x = math.max(0, max)
+  local xmargin = 3 * self:get_font():get_width(' ')
+  local xsup = xoffset + gw + xmargin
+  local xinf = xoffset - xmargin
+  if xsup > self.scroll.x + self.size.x then
+    self.scroll.to.x = xsup - self.size.x
+  elseif xinf < self.scroll.x then
+    self.scroll.to.x = math.max(0, xinf)
+  end
 end
 
 


### PR DESCRIPTION
With the new behavior when moving right and triggering a scroll in the
right direction a subsequent movement left do not longer triggers a
scrolling to the left.
The scrolling to the left happens only when needed for the visibility of
the current position.

In other terms with the old behavior the scrolling was purely a function
of the position and was adjusted even when not strictly needed for the
visibility of the cursor.
Now the scrolling is no longer a pure function of the position but it
has a "memory" behavior. The scrolling will be adjusted only if needed
to accommodate the position of the cursor.

Reduce also the width of the margin when the scrolling will be
triggered and calculate as a function of the font character width.

With the modification now Lite behaves like the other editors. In
addition the selection of text with the mouse is much more easy when
a scrolling of the line is needed.