### PR TITLE
Start in the current directory rather than EXEDIR

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -82,7 +82,7 @@ function core.init()
   CommandView = require "core.commandview"
   Doc = require "core.doc"
 
-  local project_dir = EXEDIR
+  local project_dir = "."
   local files = {}
   for i = 2, #ARGS do
     local info = system.get_file_info(ARGS[i]) or {}


### PR DESCRIPTION
This changes the behavior when `lite` is started without arguments,
e.g. from a terminal. Rather than showing `lite` installation
directory, it shows current directory, removing the need to
start `lite` as `lite .`.