### PR TITLE
+js regexp pattern

### DIFF
--- a/data/plugins/language_js.lua
+++ b/data/plugins/language_js.lua
@@ -6,6 +6,7 @@ syntax.add {
   patterns = {
     { pattern = "//.-\n",               type = "comment"  },
     { pattern = { "/%*", "%*/" },       type = "comment"  },
+    { pattern = { '/', '/', '\\' },     type = "string"   },
     { pattern = { '"', '"', '\\' },     type = "string"   },
     { pattern = { "'", "'", '\\' },     type = "string"   },
     { pattern = { "`", "`", '\\' },     type = "string"   },


### PR DESCRIPTION
Fixes wrong syntax highlighting when regexp contains unmatched quotes (i.e. `.replace(/"/g, "&quot;");`)