### PR TITLE
Add Makefile, update build instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/*
+lite

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+PREFIX ?= /usr/local
+TARGET ?= lite
+
+OBJ_DIR ?= $(shell pwd)/build
+SRC_DIR := $(shell pwd)/src
+
+SRC_EXT := c
+OBJ_EXT := o
+
+SRCS := $(shell find $(SRC_DIR) -name *.$(SRC_EXT))
+
+SOURCES := $(foreach sname, $(SRCS), $(abspath $(sname)))
+OBJECTS := $(patsubst $(SRC_DIR)/%.$(SRC_EXT), $(OBJ_DIR)/%.$(OBJ_EXT), $(SOURCES))
+
+CC := gcc
+CFLAGS ?=
+LDLAGS ?=
+
+CFLAGS +=-Wall -O3 -g -std=gnu11 -fno-strict-aliasing -Isrc -fPIC -DLUA_COMPAT_ALL
+LDFLAGS +=-lSDL2 -lm
+
+UNAME := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+CFLAGS +=-DLUA_USE_POSIX
+endif
+
+all: $(TARGET)
+
+$(TARGET): $(OBJECTS)
+	$(CC) $^ -o $@ $(LDFLAGS)
+
+$(OBJ_DIR)/%$(OBJ_EXT): $(SRC_DIR)/%$(SRC_EXT)
+	mkdir -p $(dir $@)
+	$(CC) -c $(CFLAGS) $< -o $@
+
+clean:
+	-rm -f $(OBJECTS) $(TARGET)
+
+.PHONY: clean
+
+install: all
+	@echo Installing to $(DESTDIR)$(PREFIX) ...
+	@mkdir -p $(DESTDIR)$(PREFIX)/bin/
+	@cp -fp $(TARGET) $(DESTDIR)$(PREFIX)/bin/
+	@echo Complete.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PREFIX ?= /usr/local
+PREFIX ?= $(HOME)/.local
 TARGET ?= lite
 
 OBJ_DIR ?= $(shell pwd)/build
@@ -16,12 +16,12 @@ CC := gcc
 CFLAGS ?=
 LDLAGS ?=
 
-CFLAGS +=-Wall -O3 -g -std=gnu11 -fno-strict-aliasing -Isrc -fPIC -DLUA_COMPAT_ALL
-LDFLAGS +=-lSDL2 -lm
+CFLAGS +=-Wall -O3 -g -std=gnu11 -fno-strict-aliasing -Isrc
+LDFLAGS +=-lSDL2 -lm -ldl
 
 UNAME := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
-CFLAGS +=-DLUA_USE_POSIX
+CFLAGS +=-DLUA_USE_POSIX -fPIC -DLUA_COMPAT_ALL
 endif
 
 all: $(TARGET)
@@ -30,7 +30,7 @@ $(TARGET): $(OBJECTS)
 	$(CC) $^ -o $@ $(LDFLAGS)
 
 $(OBJ_DIR)/%$(OBJ_EXT): $(SRC_DIR)/%$(SRC_EXT)
-	mkdir -p $(dir $@)
+	@mkdir -p $(dir $@)
 	$(CC) -c $(CFLAGS) $< -o $@
 
 clean:
@@ -39,7 +39,10 @@ clean:
 .PHONY: clean
 
 install: all
-	@echo Installing to $(DESTDIR)$(PREFIX) ...
-	@mkdir -p $(DESTDIR)$(PREFIX)/bin/
-	@cp -fp $(TARGET) $(DESTDIR)$(PREFIX)/bin/
+	@echo Installing to $(PREFIX) ...
+	@mkdir -p $(PREFIX)/bin/
+	@cp -fp $(TARGET) $(PREFIX)/bin/
+	@mkdir -p $(PREFIX)/bin/data
+	@echo Copying lua files to $(PREFIX)/bin/data
+	@cp -r data/* $(PREFIX)/bin/data/
 	@echo Complete.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 PREFIX ?= $(HOME)/.local
-TARGET ?= lite
 
 OBJ_DIR ?= $(shell pwd)/build
 SRC_DIR := $(shell pwd)/src
@@ -12,16 +11,25 @@ SRCS := $(shell find $(SRC_DIR) -name *.$(SRC_EXT))
 SOURCES := $(foreach sname, $(SRCS), $(abspath $(sname)))
 OBJECTS := $(patsubst $(SRC_DIR)/%.$(SRC_EXT), $(OBJ_DIR)/%.$(OBJ_EXT), $(SOURCES))
 
-CC := gcc
 CFLAGS ?=
 LDLAGS ?=
 
 CFLAGS +=-Wall -O3 -g -std=gnu11 -fno-strict-aliasing -Isrc
 LDFLAGS +=-lSDL2 -lm -ldl
 
-UNAME := $(shell uname -s)
-ifeq ($(UNAME_S),Linux)
-CFLAGS +=-DLUA_USE_POSIX -fPIC -DLUA_COMPAT_ALL
+ifeq ($(OS),Windows_NT)
+  TARGET ?= lite.exe
+  CC := x86_64-w64-mingw32-gcc
+  CFLAGS += -DLUA_USE_POPEN -Iwinlib/SDL2-2.0.10/x86_64-w64-mingw32/include
+  LDFLAGS += -Lwinlib/SDL2-2.0.10/x86_64-w64-mingw32/lib -lmingw32 -lSDL2main -mwindows res.res
+	x86_64-w64-mingw32-windres res.rc -O coff -o res.res
+else
+  TARGET ?= lite
+  CC := gcc
+  UNAME := $(shell uname -s)
+  ifeq ($(UNAME_S),Linux)
+    CFLAGS +=-DLUA_USE_POSIX -fPIC -DLUA_COMPAT_ALL
+  endif
 endif
 
 all: $(TARGET)

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ You can build the project yourself on Linux with following prerequisites:
 #### Debian/Ubuntu
 
 ```
-sudo apt install libsdl2-dev gcc
-./build.sh
+sudo apt install libsdl2-dev gcc make
+make
 ```
 
 ### Windows

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ You can build the project yourself on Linux with following prerequisites:
 ```
 sudo apt install libsdl2-dev gcc make
 make
+sudo make install PREFIX=/usr/local
 ```
 
 ### Windows

--- a/README.md
+++ b/README.md
@@ -24,8 +24,24 @@ The editor can be customized by making changes to the
 [user module](data/user/init.lua).
 
 ## Building
-You can build the project yourself on Linux using the `build.sh` script
-or on Windows using the `build.bat` script *([MinGW](https://nuwen.net/mingw.html) is required)*.
+
+### Linux
+
+You can build the project yourself on Linux with following prerequisites:
+
+ * GCC
+ * Simple DirectMedia Layer development files
+
+#### Debian/Ubuntu
+
+```
+sudo apt install libsdl2-dev gcc
+./build.sh
+```
+
+### Windows
+
+Using the `build.bat` script *([MinGW](https://nuwen.net/mingw.html) is required)*.
 Note that the project does not need to be rebuilt if you are only making changes
 to the Lua portion of the code.
 


### PR DESCRIPTION
I've added a simple `Makefile` but I'm struggling a bit project structure.
E.g. when installing to `/usr/local` Lua files could be placed in `/usr/local/share/lua/5.2/core.lua`. It would be nicer to put also package name on path, so that Lite's files won't collide with some other Lua package, e.g. `/usr/local/share/lua/5.2/lite/core.lua`
```
Error: [string "local core..."]:8: module 'core' not found:
        no field package.preload['core']
        no file '/usr/local/bin/data/core/init.lua'
        no file '/usr/local/bin/data/core.lua'
        no file '/usr/local/share/lua/5.2/core.lua'
        no file '/usr/local/share/lua/5.2/core/init.lua'
        no file '/usr/local/lib/lua/5.2/core.lua'
        no file '/usr/local/lib/lua/5.2/core/init.lua'
        no file './core.lua'
        no file '/usr/local/lib/lua/5.2/core.so'
        no file '/usr/local/lib/lua/5.2/loadall.so'
        no file './core.so'
``` 
Also, fonts are currently hard-coded relatively to executable:
```
data/plugins/scale.lua:19:font_cache[style.code_font] = { EXEDIR .. "/data/fonts/monospace.ttf", 13.5 * SCALE }
```
but this would be for another PR. Is it ok to modify this path?

A Linux program structure might look like
```
/usr/local/bin/lite
/usr/local/share/lua/5.2/lite/core/...
/usr/local/share/lua/5.2/lite/fonts/...
/var/lib/lite/plugins/
/var/lib/lite/user/
~/.local/lite/plugins/
~/.local/lite/user/
```

Currently all files needs to be placed relatively to e.g. `/usr/local/bin/lite` file, in `/usr/local/bin/lite/data/` directory which isn't nice.
