### PR TITLE
docview: fix rounding bug in get_line_text_y_offset

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -119,9 +119,8 @@ end
 
 
 function DocView:get_line_text_y_offset()
-  local lh = self:get_line_height()
   local th = self:get_font():get_height()
-  return (lh - th) / 2
+  return math.floor(th*config.line_height - th)
 end
 
 


### PR DESCRIPTION
Vertically center text in selection. `get_line_height` already rounds down and that made the text seem “stuck to the top“ in selections. Rounding down after calculating the offset using doubles fixes this for me.

Cheers! As always a bliss to play with lite!