### PR TITLE
Reduce idle cpu usage

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -377,6 +377,9 @@ function core.step()
     end
     core.redraw = true
   end
+
+  if not core.redraw and not system.window_has_focus() then return false end
+
   if mouse_moved then
     core.try(core.on_event, "mousemoved", mouse.x, mouse.y, mouse.dx, mouse.dy)
   end
@@ -453,9 +456,6 @@ function core.run()
     core.frame_start = system.get_time()
     local did_redraw = core.step()
     run_threads()
-    if not did_redraw and not system.window_has_focus() then
-      system.wait_event(0.25)
-    end
     local elapsed = system.get_time() - core.frame_start
     system.sleep(math.max(0, 1 / config.fps - elapsed))
   end

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -132,13 +132,6 @@ top:
 }
 
 
-static int f_wait_event(lua_State *L) {
-  double n = luaL_checknumber(L, 1);
-  lua_pushboolean(L, SDL_WaitEventTimeout(NULL, n * 1000));
-  return 1;
-}
-
-
 static SDL_Cursor* cursor_cache[SDL_SYSTEM_CURSOR_HAND + 1];
 
 static const char *cursor_opts[] = {
@@ -381,7 +374,6 @@ static int f_fuzzy_match(lua_State *L) {
 
 static const luaL_Reg lib[] = {
   { "poll_event",          f_poll_event          },
-  { "wait_event",          f_wait_event          },
   { "set_cursor",          f_set_cursor          },
   { "set_window_title",    f_set_window_title    },
   { "set_window_mode",     f_set_window_mode     },


### PR DESCRIPTION
This pull request reduces the high idle CPU utilization (at least on Linux) discussed in #73. I have not tested this on windows. SDL_WaitEvent uses more CPU than simply polling events on each frame tick. With 60fps the CPU utilization is now 0.7 - 1%. Before it was 4%.