### PR TITLE
set project_dir to file location on startup if applicable

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -87,7 +87,12 @@ function core.init()
   for i = 2, #ARGS do
     local info = system.get_file_info(ARGS[i]) or {}
     if info.type == "file" then
-      table.insert(files, system.absolute_path(ARGS[i]))
+      local abs_path = system.absolute_path(ARGS[i])
+      table.insert(files, abs_path)
+      local dir = abs_path:match("^(.*)[/\\]")
+      if dir then
+        project_dir = dir
+      end
     elseif info.type == "dir" then
       project_dir = ARGS[i]
     end


### PR DESCRIPTION
When launching lite with a file path as an argument, set the current project directory to that file's location

Honestly I find it quite strange that nobody has suggested this before because to me it seems very obvious that this is how it should work. Opening lite's own install directory as the project directory when supplied with a file to open, doesn't really make any sense.

